### PR TITLE
should abort on daos init if pool/cont/svcl not specified.

### DIFF
--- a/src/aiori-DAOS.c
+++ b/src/aiori-DAOS.c
@@ -258,8 +258,11 @@ DAOS_Init()
 	if (daos_initialized)
 		return;
 
-	if (o.pool == NULL || o.svcl == NULL || o.cont == NULL)
+	if (o.pool == NULL || o.svcl == NULL || o.cont == NULL) {
+		GERR("Invalid DAOS pool/cont\n");
 		return;
+	}
+
         if (o.oclass)
                 ObjectClassParse(o.oclass);
 


### PR DESCRIPTION
Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>