### PR TITLE
add sleep depending on MPI rank to avoid all ranks calling daos_fini()

### DIFF
--- a/src/aiori-DAOS.c
+++ b/src/aiori-DAOS.c
@@ -17,6 +17,8 @@
  * This file implements the abstract I/O interface for DAOS Array API.
  */
 
+#define _BSD_SOURCE
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -319,6 +321,9 @@ DAOS_Fini()
 
 	rc = daos_pool_disconnect(poh, NULL);
 	DCHECK(rc, "Failed to disconnect from pool %s", o.pool);
+
+	MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD), "barrier error");
+	usleep(20000 * rank);
 
         rc = daos_fini();
         DCHECK(rc, "Failed to finalize daos");

--- a/src/aiori-DFS.c
+++ b/src/aiori-DFS.c
@@ -16,6 +16,8 @@
  * This file implements the abstract I/O interface for DAOS FS API.
  */
 
+#define _BSD_SOURCE
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -470,6 +472,9 @@ DFS_Finalize()
 
         daos_pool_disconnect(poh, NULL);
         DCHECK(rc, "Failed to disconnect from pool");
+
+	MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD), "barrier error");
+	usleep(20000 * rank);
 
 	rc = daos_fini();
         DCHECK(rc, "Failed to finalize DAOS");


### PR DESCRIPTION
at once (issue with PSM2).

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>